### PR TITLE
Fix/1: BarChart의 axis에서 중복된 값이 나올 경우 발생하던 버그 수정

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -31,10 +31,15 @@ export default function BarChart({
       .range([0, dimensions.height]);
 
     const valueAxisScale = scaleBand()
-      .domain(data.map((value: any) => value.value))
+      .domain(data.map((value: IBarChartData, index: number) => value.value + '-' + index))
       .range([0, dimensions.height]);
 
-    const valueAxis: any = axisLeft(valueAxisScale).tickSize(0).tickPadding(12);
+    const valueAxis: any = axisLeft(valueAxisScale)
+      .tickSize(0)
+      .tickPadding(12)
+      .tickFormat(function (d) {
+        return d.split('-')[0];
+      });
 
     svg.select('.value-axis').call(valueAxis);
 


### PR DESCRIPTION
- BarChart에서 활성화된 스테이터스의 값들 중 중복된 값이 있으면 axis에 제대로 표시되지 않는 버그 발생
- 원인 : band scale의 domain key값은 항상 unique 이어야 한다. 따라서 중복된 값이 있다면 누락된다.
- 해결: key값을 unique하게 만든 후 tickFormat을 활용하여 key값을 가공 후 출력
- 결과: 중복된 값들도 정상적으로 출력됨