### PR TITLE
Feat/11: tps, 현재 사용자 초기값 설정

### DIFF
--- a/src/reducer/reducer.ts
+++ b/src/reducer/reducer.ts
@@ -1,6 +1,7 @@
 import { Action, State } from './types';
 import { DataActionTypes } from './actionTypes';
 import produce from 'immer';
+import { SECOND } from '../constants';
 
 function reducer(state: State, action: Action) {
   switch (action.type) {
@@ -15,11 +16,19 @@ function reducer(state: State, action: Action) {
     case DataActionTypes.UPDATE_SPOT_DATA: {
       const nextState = produce(state, (draft: State) => {
         if (action.data.fetchName === 'activeStatus') {
+          if (action.data.promiseAllResponse.includes(undefined)) {
+            return state;
+          }
+
           draft.activeStatus.data = action.data.promiseAllResponse;
           draft.activeStatus.key = action.data.fetchName;
         }
 
         if (action.data.fetchName === 'informatics') {
+          if (action.data.promiseAllResponse.includes(undefined)) {
+            return state;
+          }
+
           draft.informatics.data = action.data.promiseAllResponse;
           draft.informatics.key = action.data.fetchName;
         }
@@ -34,10 +43,28 @@ function reducer(state: State, action: Action) {
           };
 
           const nextState = produce(state, (draft: State) => {
-            draft.tps.key = action.data.fetchName;
-            draft.tps.data.push(dataWithTimeStamp);
+            if (!state.tps.data.length) {
+              const initialData = [];
 
-            if (draft.tps.data.length > 120) draft.tps.data.shift();
+              for (let i = 119; i > -1; i--) {
+                initialData.push({
+                  timeStamp: date - SECOND * 5 * i,
+                  data: isNaN(action.data.promiseAllResponse[0])
+                    ? state.tps.data[state.tps.data.length - 1].data
+                    : Number(action.data.promiseAllResponse[0]),
+                });
+              }
+
+              draft.tps.key = action.data.fetchName;
+              draft.tps.data = initialData;
+            } else {
+              draft.tps.key = action.data.fetchName;
+              draft.tps.data.push(dataWithTimeStamp);
+
+              if (draft.tps.data.length > 120) {
+                draft.tps.data.shift();
+              }
+            }
           });
 
           return nextState;
@@ -53,10 +80,28 @@ function reducer(state: State, action: Action) {
           };
 
           const nextState = produce(state, (draft: State) => {
-            draft.simultaneousUser.key = action.data.fetchName;
-            draft.simultaneousUser.data.push(dataWithTimeStamp);
+            if (!state.simultaneousUser.data.length) {
+              const initialData = [];
 
-            if (draft.simultaneousUser.data.length > 120) draft.simultaneousUser.data.shift();
+              for (let i = 119; i > -1; i--) {
+                initialData.push({
+                  timeStamp: date - SECOND * 5 * i,
+                  data: isNaN(action.data.promiseAllResponse[0])
+                    ? state.simultaneousUser.data[state.simultaneousUser.data.length - 1].data
+                    : Number(action.data.promiseAllResponse[0]),
+                });
+              }
+
+              draft.simultaneousUser.key = action.data.fetchName;
+              draft.simultaneousUser.data = initialData;
+            } else {
+              draft.simultaneousUser.key = action.data.fetchName;
+              draft.simultaneousUser.data.push(dataWithTimeStamp);
+
+              if (draft.simultaneousUser.data.length > 120) {
+                draft.simultaneousUser.data.shift();
+              }
+            }
           });
 
           return nextState;


### PR DESCRIPTION
- tps 최초 fetch 시에는 series, 이후 최신화는 spot → 현재시간 데이터부터 fetch를 하기 때문에 최초에는 빈 차트가 나타나는 것을 방지하자.
    - 생각 1
        - transactin/{stime}/{etime} series api를 활용
        - stime과 etime 사이에 발생한 transaction을 service주소(url) 단위로 응답을 받음
        - time_sum, time_avg를 활용하면 해당 service주소가 stime ~ etime 사이에 수행한 트랜잭션 수(count)를 얻을 수 있음
        - 그러나 응답에는 각 트랜잭션의 timestamp가 없기 때문에 트랜잭션이 발생한 정확한 시점은 할 수 없음 → 5초당 트랜잭션 갯수를 알 수 없음 → 차트에 표시 불가
    - 생각 2
        - 그렇다면 5초 단위의 transactin/{stime}/{etime} api를 120번 요청해서 10분 간의 데이터를 얻는다
        - transactin/{stime}/{etime} api는 5초간 데이터는 빈 응답을 받음
        - 다양한 값의 stime, etime으로 확인해 본 결과 4분 간격의 데이터부터 응답을 받을 수 있었음
    - 결론: 초기값으로 tps를 받는 방법은 현재 api로는 어렵다고 판단하여 초기 fetch값을 이전 10분의 값들로 설정하는 방법으로 구현 - tps 데이터를 series로 받을 수 있는 방법이 있다면 수정할 것